### PR TITLE
Add 1.16 support and fix a CME

### DIFF
--- a/api/src/main/java/de/leonkoth/blockparty/version/BlockPartyMaterial.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/BlockPartyMaterial.java
@@ -28,13 +28,8 @@ public abstract class BlockPartyMaterial implements IVersionedMaterial {
     protected abstract String getSuffix();
 
     @Override
-    public Boolean equals(Material material) {
-        for (Material m : this.materials)
-        {
-            if (m.equals(material))
-                return true;
-        }
-        return false;
+    public boolean equals(Material material) {
+        return materials.contains(material);
     }
 
     @Override

--- a/api/src/main/java/de/leonkoth/blockparty/version/IVersionedMaterial.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/IVersionedMaterial.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 public interface IVersionedMaterial {
 
-    Boolean equals(Material material);
+    boolean equals(Material material);
 
     Material get(int t);
 

--- a/api/src/main/java/de/leonkoth/blockparty/version/Version.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/Version.java
@@ -18,6 +18,9 @@ public class Version { // package-private
     public static final Version CURRENT_VERSION = new Version();
 
     //region VERSIONS
+    public static final Version v1_16_3 = new Version(1, 16, 3, "v1_16_R2");
+    public static final Version v1_16_2 = new Version(1, 16, 2, "v1_16_R2");
+    public static final Version v1_16_1 = new Version(1, 16, 1, "v1_16_R1");
     public static final Version v1_15_2 = new Version(1, 15, 2, "v1_15_R1");
     public static final Version v1_15_1 = new Version(1, 15, 1, "v1_15_R1");
     public static final Version v1_15 = new Version(1, 15, "v1_15_R1");

--- a/api/src/main/java/de/leonkoth/blockparty/version/VersionedMaterial.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/VersionedMaterial.java
@@ -1,6 +1,5 @@
 package de.leonkoth.blockparty.version;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
 import java.util.ArrayList;
@@ -30,7 +29,7 @@ public enum VersionedMaterial implements IVersionedMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return bpMaterial.equals(material);
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,9 +85,9 @@
 
         <!-- NoteBlockAPI -->
         <dependency>
-            <groupId>com.github.xxmicloxx</groupId>
+            <groupId>com.github.koca2000</groupId>
             <artifactId>NoteBlockAPI</artifactId>
-            <version>7f6c9cd5fa</version>
+            <version>1.6.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/core/src/main/java/de/leonkoth/blockparty/command/BlockPartyLeaveCommand.java
+++ b/core/src/main/java/de/leonkoth/blockparty/command/BlockPartyLeaveCommand.java
@@ -41,7 +41,7 @@ public class BlockPartyLeaveCommand extends SubCommand {
             throw new BlockPartyException("Arena " + playerInfo.getCurrentArena() + " does not exist or got deleted.");
         }
 
-        if (!arena.removePlayer(player)) {
+        if (!arena.removePlayer(playerInfo)) {
             Bukkit.getConsoleSender().sendMessage("§c[BlockParty] " + player.getName() + " couldn't leave arena " + arena.getName());
             return false;
         }

--- a/core/src/main/java/de/leonkoth/blockparty/floor/Floor.java
+++ b/core/src/main/java/de/leonkoth/blockparty/floor/Floor.java
@@ -12,6 +12,7 @@ import de.leonkoth.blockparty.player.PlayerState;
 import de.leonkoth.blockparty.util.Bounds;
 import de.leonkoth.blockparty.util.ColorBlock;
 import de.leonkoth.blockparty.util.Size;
+import de.pauhull.utils.misc.MinecraftVersion;
 import de.pauhull.utils.particle.ParticlePlayer;
 import lombok.Getter;
 import lombok.Setter;
@@ -30,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static de.pauhull.utils.misc.MinecraftVersion.v1_13;
+
 /**
  * Created by Leon on 14.03.2018.
  * Project Blockparty2
@@ -37,7 +40,7 @@ import java.util.Random;
  */
 public class Floor {
 
-    private static Random random = new Random();
+    private Random random = new Random();
 
     @Getter
     private Arena arena;
@@ -192,11 +195,12 @@ public class Floor {
     }
 
     public void removeBlocks() {
-        byte data = currentBlock.getData();
+        byte data = MinecraftVersion.CURRENT_VERSION.isLower(v1_13) ? currentBlock.getData() : 0;
         Material material = currentBlock.getType();
 
         for (Block block : getFloorBlocks()) {
-            if (block.getData() != data || block.getType() != material) {
+            byte floorData = MinecraftVersion.CURRENT_VERSION.isLower(v1_13) ? block.getData() : 0;
+            if (floorData != data || block.getType() != material) {
                 block.setType(Material.AIR);
             }
         }
@@ -233,8 +237,12 @@ public class Floor {
     }
 
     public void updateInventories(Block block) {
-
-        ItemStack stack = new ItemStack(block.getType(), 1, block.getData());
+        ItemStack stack;
+        if (MinecraftVersion.CURRENT_VERSION.isLower(v1_13)) {
+            stack = new ItemStack(block.getType(), 1, block.getData());
+        } else {
+            stack = new ItemStack(block.getType(), 1);
+        }
         ItemMeta meta = stack.getItemMeta();
         String name = ColorBlock.get(block).getName();
         meta.setDisplayName("§f§l§o" + name);

--- a/core/src/main/java/de/leonkoth/blockparty/listener/PlayerInteractListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/PlayerInteractListener.java
@@ -110,7 +110,7 @@ public class PlayerInteractListener implements Listener {
                 }
 
                 Arena arena = playerInfo.getCurrentArena();
-                arena.removePlayer(player);
+                arena.removePlayer(playerInfo);
 
                 return;
             }

--- a/core/src/main/java/de/leonkoth/blockparty/listener/PlayerLeaveArenaListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/PlayerLeaveArenaListener.java
@@ -42,7 +42,6 @@ public class PlayerLeaveArenaListener implements Listener {
         this.blockParty.getPlayerInfoManager().savePlayerInfo(playerInfo);
 
         arena.broadcast(PREFIX, PLAYER_LEFT_GAME, false, playerInfo, "%PLAYER%", player.getName());
-        arena.getPlayersInArena().remove(playerInfo);
 
         if (arena.getArenaState() == ArenaState.INGAME) {
             arena.eliminate(playerInfo);

--- a/core/src/main/java/de/leonkoth/blockparty/listener/PlayerQuitListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/PlayerQuitListener.java
@@ -36,7 +36,7 @@ public class PlayerQuitListener implements Listener {
         Arena arena = playerInfo.getCurrentArena();
 
         if (arena != null)
-            arena.removePlayer(player);
+            arena.removePlayer(playerInfo);
     }
 
 }

--- a/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/BlockPartyMaterials.java
+++ b/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/BlockPartyMaterials.java
@@ -189,7 +189,7 @@ public class BlockPartyMaterials implements IBlockPartyMaterials {
 
     @Override
     public Material FIREBALL() {
-        return Material.LEGACY_FIREBALL;
+        return Material.FIRE_CHARGE;
     }
 
 }

--- a/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/materials/Door.java
+++ b/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/materials/Door.java
@@ -1,11 +1,7 @@
 package de.leonkoth.blockparty.version.v1_13_R1.materials;
 
 import de.leonkoth.blockparty.version.BlockPartyMaterial;
-import de.leonkoth.blockparty.version.IVersionedMaterial;
 import org.bukkit.Material;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Package de.leonkoth.blockparty.version.v1_13_R1.materials
@@ -30,7 +26,7 @@ public class Door extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.door;
     }
 

--- a/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/materials/FireCharge.java
+++ b/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/materials/FireCharge.java
@@ -26,7 +26,7 @@ public class FireCharge extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.fireCharge;
     }
 

--- a/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/materials/SkeletonSkull.java
+++ b/spigot_v1_13_R1/src/main/java/de/leonkoth/blockparty/version/v1_13_R1/materials/SkeletonSkull.java
@@ -26,7 +26,7 @@ public class SkeletonSkull extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.skeletonSkull;
     }
 

--- a/spigot_v1_14_R1/src/main/java/de/leonkoth/blockparty/version/v1_14_R1/materials/Sign.java
+++ b/spigot_v1_14_R1/src/main/java/de/leonkoth/blockparty/version/v1_14_R1/materials/Sign.java
@@ -1,7 +1,7 @@
 package de.leonkoth.blockparty.version.v1_14_R1.materials;
 
 import de.leonkoth.blockparty.version.BlockPartyMaterial;
-import org.bukkit.Material;
+import org.bukkit.Tag;
 
 
 /**
@@ -15,18 +15,7 @@ public class Sign extends BlockPartyMaterial {
     public Sign()
     {
         super();
-        this.materials.add(Material.SPRUCE_SIGN);
-        this.materials.add(Material.SPRUCE_WALL_SIGN);
-        this.materials.add(Material.ACACIA_SIGN);
-        this.materials.add(Material.ACACIA_WALL_SIGN);
-        this.materials.add(Material.BIRCH_SIGN);
-        this.materials.add(Material.BIRCH_WALL_SIGN);
-        this.materials.add(Material.DARK_OAK_SIGN);
-        this.materials.add(Material.DARK_OAK_WALL_SIGN);
-        this.materials.add(Material.JUNGLE_SIGN);
-        this.materials.add(Material.JUNGLE_WALL_SIGN);
-        this.materials.add(Material.OAK_SIGN);
-        this.materials.add(Material.OAK_WALL_SIGN);
+        this.materials.addAll(Tag.SIGNS.getValues());
     }
 
     @Override

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Carpet.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Carpet.java
@@ -26,7 +26,7 @@ public class Carpet extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.carpet;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Door.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Door.java
@@ -26,7 +26,7 @@ public class Door extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.door;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/FireCharge.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/FireCharge.java
@@ -26,7 +26,7 @@ public class FireCharge extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.fireCharge;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/SkeletonSkull.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/SkeletonSkull.java
@@ -26,7 +26,7 @@ public class SkeletonSkull extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.skeletonSkull;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/StainedGlass.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/StainedGlass.java
@@ -26,7 +26,7 @@ public class StainedGlass extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.stainedGlass;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/StainedGlassPane.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/StainedGlassPane.java
@@ -26,7 +26,7 @@ public class StainedGlassPane extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.stainedGlassPane;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Terracotta.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Terracotta.java
@@ -27,7 +27,7 @@ public class Terracotta extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.terracotta;
     }
 

--- a/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Wool.java
+++ b/spigot_v1_8_R3/src/main/java/de.leonkoth.blockparty.version.v1_8_R3/materials/Wool.java
@@ -26,7 +26,7 @@ public class Wool extends BlockPartyMaterial {
     }
 
     @Override
-    public Boolean equals(Material material) {
+    public boolean equals(Material material) {
         return material == this.wool;
     }
 

--- a/utils/src/main/java/de/pauhull/utils/misc/MinecraftVersion.java
+++ b/utils/src/main/java/de/pauhull/utils/misc/MinecraftVersion.java
@@ -17,6 +17,9 @@ public class MinecraftVersion {
     public static final MinecraftVersion CURRENT_VERSION = new MinecraftVersion();
 
     //region VERSIONS
+    public static final MinecraftVersion v1_16_3 = new MinecraftVersion(1, 16, 3, "v1_16_R2");
+    public static final MinecraftVersion v1_16_2 = new MinecraftVersion(1, 16, 2, "v1_16_R2");
+    public static final MinecraftVersion v1_16_1 = new MinecraftVersion(1, 16, 1, "v1_16_R1");
     public static final MinecraftVersion v1_15_2 = new MinecraftVersion(1, 15, 2, "v1_15_R1");
     public static final MinecraftVersion v1_15_1 = new MinecraftVersion(1, 15, 1, "v1_15_R1");
     public static final MinecraftVersion v1_15 = new MinecraftVersion(1, 15, "v1_15_R1");


### PR DESCRIPTION
Hello,

This PR adds support for version 1.16.x (NMS + new sign types) and fixes the *ConcurrentModificationException* from #26. Note that this fix is a bit tricky, I tested the 4 cases where the player could leave the arena and it doesn't seem to cause a problem.

Also, the ChatFace util could handle RGB colors, but that would require the bungee api included in Spigot (`net.md-5:bungeecord-chat:1.16`) and I don't know if this would be appropriate.